### PR TITLE
[dev]: support nested keys in the languages.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin is inspired by [coc.nvim](https://github.com/neoclide/coc.nvim) and 
 ### Highlight of Features
 
 - [x] Load default server configurations from specific path, e.g. `~/.config/nvim/languages.json`,
-- [x] Find the `.config/nvim/languages.json` in the root path of porject, or current work directory, and load it,
+- [x] Find the `.nvim/languages.json` in the root path of porject, or current work directory, and load it,
 - [x] highly customized lsp,
 - [ ] Support load servers from `.lua` files,
 - [ ] Provide user command to load specific server configuration from configuration,
@@ -33,19 +33,22 @@ use {
     config = function()
         -- DEFAULT CONFIGURATION
         require('nvim-lsp-loader').setup({
-            -- where to find the default server configuations, could be nil
+            ---@type string | nil where to find the default server configuations, could be nil
             default_config_path = '~/.config/nvim/languages.json',
 
-            -- the patterns to detect the root of project
+            ---@type table<string> the patterns to detect the root of project
             root_patterns = { '.git/' },
 
-            -- callback when server is attached to buffer, could be nil
+            ---@type function | nil callback when server is attached to buffer, could be nil
+            ---@param client_id integer
+            ---@param bufnr integer
             on_attach = nil,
 
-            -- to overwrite the capabilities of server, could be nil
+            ---@type function | nil to overwrite the capabilities of server, could be nil
+            ---@return table language server capabilities
             make_capabilities = nil,
 
-            -- callback for resolving server configuration, would be invoked before server setup
+            ---@type function | nil callback for resolving server configuration, would be invoked before server setup
             -- accept server name and server config as input
             server_config_cb = nil,
 
@@ -164,6 +167,8 @@ __NOTICE:__ Comments is not supported in many json decoder.
     }
 }
 ```
+
+Another example from my neovim configuration: [Click Here](https://github.com/zhang-stephen/dotfiles-on-unix-like/blob/master/nvim/languages.json).
 
 #### How the configuration to be loaded?
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ use {
             ---@type string | nil where to find the default server configuations, could be nil
             default_config_path = '~/.config/nvim/languages.json',
 
+            ---@type boolean support nested json keys or not, default is false
+            nested_json_keys = false,
+
             ---@type table<string> the patterns to detect the root of project
             root_patterns = { '.git/' },
 
@@ -49,7 +52,8 @@ use {
             make_capabilities = nil,
 
             ---@type function | nil callback for resolving server configuration, would be invoked before server setup
-            -- accept server name and server config as input
+            ---@param name string the name of language server
+            ---@param config table the configuration table of language server
             server_config_cb = nil,
 
             -- work mode, must be one of {'user-first', 'user-only', 'default-first', 'default-only'}

--- a/lua/nvim-lsp-loader/json.lua
+++ b/lua/nvim-lsp-loader/json.lua
@@ -1,0 +1,57 @@
+-- algorithms about json processing
+-- NOTE: DO NOT import any library from neovim in this scope
+
+local json = {}
+local util = require('nvim-lsp-loader.util')
+
+---@param data string json string to be decoded
+json.decode = function(data)
+    local ok, result = pcall(vim.fn.json_decode, data)
+    return ok and result or nil
+end
+
+---@param t table
+---@return table
+json.inflate = function (t)
+    local res = {}
+
+    -- if t is list or not a table, return it directly
+    if type(t) ~= 'table' or util.is_array(t) then
+        return t
+    end
+
+    for key, val in pairs(t) do
+        local keys = {}
+        local cursor = res
+        val = type(val) == 'table' and json.inflate(val) or val
+
+        for k in string.gmatch(key, '[^.]+') do
+            table.insert(keys, k)
+        end
+
+        for i, k in ipairs(keys) do
+            -- for nested keys:
+            -- create an empty table if cursor[k] is nil
+            cursor[k] = cursor[k] ~= nil and cursor[k] or {}
+
+            -- the cursor has arrived the deepest of the table,
+            -- and the value will be assigned to the deepest key.
+            if i == #keys then
+                if type(val) == "table" then
+                    for _1, _2 in pairs(val) do
+                        cursor[k][_1] = _2
+                    end
+                else
+                    cursor[k] = val
+                end
+            end
+
+            -- move cursor to the deeper
+            cursor = cursor[k]
+        end
+    end
+
+    return res
+end
+
+return json

--- a/lua/nvim-lsp-loader/json.lua
+++ b/lua/nvim-lsp-loader/json.lua
@@ -12,7 +12,7 @@ end
 
 ---@param t table
 ---@return table
-json.inflate = function (t)
+json.inflate = function(t)
     local res = {}
 
     -- if t is list or not a table, return it directly
@@ -37,7 +37,7 @@ json.inflate = function (t)
             -- the cursor has arrived the deepest of the table,
             -- and the value will be assigned to the deepest key.
             if i == #keys then
-                if type(val) == "table" then
+                if type(val) == 'table' then
                     for _1, _2 in pairs(val) do
                         cursor[k][_1] = _2
                     end

--- a/lua/nvim-lsp-loader/loader.lua
+++ b/lua/nvim-lsp-loader/loader.lua
@@ -48,7 +48,7 @@ end
 
 ---@param lang string the name of language
 ---@param server table server configuration read from json
----@param plugin_conf table configuratio of plugin itself
+---@param plugin_conf table configuration of plugin itself
 ---@return boolean
 local load_server = function(lang, server, plugin_conf)
     local type_of_server_config = type(server.config)
@@ -77,14 +77,8 @@ local load_server = function(lang, server, plugin_conf)
     return true
 end
 
----@param data string data to be decoded
----@return table | nil
-loader.json_decode = function(data)
-    local ok, result = pcall(vim.fn.json_decode, data)
-    return ok and result or nil
-end
-
 ---@param servers table configurations of all servers read from json
+---@param plugin_conf table configurations of plugin itself
 loader.load_servers = function(servers, plugin_conf)
     for lang, server in pairs(servers) do
         local loaded = load_server(lang, server, plugin_conf)

--- a/lua/nvim-lsp-loader/loader.lua
+++ b/lua/nvim-lsp-loader/loader.lua
@@ -24,7 +24,7 @@ local resolve_server_conf = function(server, on_attach, make_capabilities, updat
 
     -- use this callback for user-defined operations
     if update_config_cb then
-        update_config_cb(config)
+        update_config_cb(server.name, config)
     end
 end
 
@@ -58,7 +58,7 @@ local load_server = function(lang, server, plugin_conf)
     end
 
     if type_of_server_config == 'table' then
-        resolve_server_conf(server, plugin_conf.on_attach, plugin_conf.make_capabilities, plugin_conf.config_cb)
+        resolve_server_conf(server, plugin_conf.on_attach, plugin_conf.make_capabilities, plugin_conf.server_config_cb)
         lsp[server.name].setup(server.config)
     elseif type_of_server_config == 'string' then
         -- TODO: to support load user-defined .lua files

--- a/lua/nvim-lsp-loader/util.lua
+++ b/lua/nvim-lsp-loader/util.lua
@@ -38,4 +38,33 @@ util.filereadable = function(path)
     return vim.fn.filereadable(path) == 1
 end
 
+---@return boolean
+util.has_nvim = function()
+    local ok, _ = pcall(vim.fn.has, 'nvim')
+    return ok
+end
+
+---@param t table
+---@return boolean
+util.is_array = function(t)
+    if type(t) ~= 'table' then
+        return false
+    end
+
+    if util.has_nvim() then
+        return vim.tbl_islist(t)
+    end
+
+    local i = 1
+
+    for _ in pairs(t) do
+        if t[i] == nil then
+            return false
+        end
+        i = i + 1
+    end
+    
+    return true
+end
+
 return util

--- a/lua/nvim-lsp-loader/util.lua
+++ b/lua/nvim-lsp-loader/util.lua
@@ -63,7 +63,7 @@ util.is_array = function(t)
         end
         i = i + 1
     end
-    
+
     return true
 end
 


### PR DESCRIPTION
New feature:

Nested keys, like `"managed_by.lsp_installer": true`, is supported in the `languages.json` now. This key will be parsed to lua table:

```lua
managed_by = { lsp_installer = true }
```

This feature is disabled in the default. To enable it, just set `nested_json_keys` as TRUE. I think it could help shrink the number of lines of `languages.json`.